### PR TITLE
[Discussion] Adding VS Live Share

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ This extension pack packages some of the most popular (and some of my favorite) 
   * Known issue:
     * `@model` must appear in the first line of the Razor page when you want IntelliSense for `@Model` object.
 
+### Collaboration
+
+* [VS Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)
+  * Adds real-time collaborative editing and debugging into VS Code.
+
 ### Misc
 
 * [gitignore](https://marketplace.visualstudio.com/items?itemName=codezombiech.gitignore)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "wayou.vscode-todo-highlight",
         "christian-kohler.path-intellisense",
         "pflannery.vscode-versionlens",
-        "formulahendry.dotnet-test-explorer"
+        "formulahendry.dotnet-test-explorer",
+        "MS-vsliveshare.vsliveshare"
     ]
 }


### PR DESCRIPTION
This PR proposes adding [Visual Studio Live Share](aka.ms/vsls) to this extension pack, since it's optimized for .NET Core collaborative development (as well as [JS/Angular](https://github.com/doggy8088/angular-extension-pack/pull/14) development).

// CC @doggy8088